### PR TITLE
Deploy to GH pages on push to main branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,29 @@
+name: Build & Deploy to GH Pages
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Install and Build 🔧
+        run: |
+          npm install
+          npm run build
+
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages # The branch the action should deploy to.
+          FOLDER: dist # The folder the action should deploy.
+          CLEAN: true

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,7 @@
     src="./assets/logo.png"
     height="70"
   >
-  <HelloWorld msg="Hello Vue 3.0 + Vite" />
+  <HelloWorld />
 </template>
 
 <script>

--- a/src/components/Pokemons.vue
+++ b/src/components/Pokemons.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="wrapper">
+  <div class="wrapper">
     <Pokemon
       v-for="pokemon in allPokemon"
       :key="pokemon.id"
@@ -29,7 +29,7 @@ export default {
 </script>
 
 <style scoped>
-  #wrapper {
+  .wrapper {
     display: grid;
     grid-gap: 70px 20px;
     grid-template-columns: repeat(auto-fit, 200px);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,5 @@
+/* eslint-disable no-undef */
+
+module.exports = {
+  base: './'
+};


### PR DESCRIPTION
Tested on my fork and it deploys alright - had an issue with some styles, which could be a bug in the version of vite we're using, or because wrapper was styled via. id. Either way I've changed wrapper to a class now.

### Added
* `.nojekyll` file required for `_x/` routes to work in GH pages
* `vite.config.js` to set the base url as `./` (otherwise assets sourced from `/` which doesn't work in GH pages)
* Action pretty basic, pushes to the gh-pages branch, cleaning before it does

Note for HH - you don't need to generate a token, the one it uses is automagically filled in via. actions